### PR TITLE
Enable device orientation for mobile game

### DIFF
--- a/MRcade_kspace/index.html
+++ b/MRcade_kspace/index.html
@@ -29,6 +29,7 @@
     <span id="remoteTiltStatus" class="small"></span>
     <span class="small" style="margin-left:12px">Device tilt:</span>
     <span id="localTiltStatus" class="small"></span>
+    <button id="enableTilt" style="display:none; margin-left:8px">Enable tilt</button>
     <label style="margin-left:12px">Marker size <input id="markerSize" type="number" value="6" min="1" max="16" step="1" style="width:64px"></label>
     <label style="margin-left:12px"><input type="checkbox" id="acqWeight"> Acquisition weighting</label>
   </div>


### PR DESCRIPTION
Add an "Enable tilt" button and robust device orientation permission handling to fix mobile sensor access.

The previous implementation failed on devices requiring explicit permission requests (e.g., iOS 13+) or a secure context (e.g., Android Chrome over HTTP), leading to "not available" status. This PR introduces a button to trigger permission requests and provides clearer status messages, including guidance for secure contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce12b7c4-ba96-4120-b8ec-ce1786f097b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce12b7c4-ba96-4120-b8ec-ce1786f097b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

