### PR TITLE
Set curl mode as default on startup

### DIFF
--- a/MRcade_kspace/app.js
+++ b/MRcade_kspace/app.js
@@ -858,6 +858,14 @@ attachMaskPainting();
 redrawMaskCanvas();
 process();
 
+// Enable curl (ship) mode by default on startup
+gradModeEl.checked = false;
+pongModeEl.checked = false;
+shipModeEl.checked = true;
+stopPong();
+stopGrad();
+startShip();
+
 function computeAvgNonZeroSumInImageData(imgData) {
   const d = imgData.data;
   let sum = 0, count = 0;

--- a/MRcade_kspace/index.html
+++ b/MRcade_kspace/index.html
@@ -23,7 +23,7 @@
   <div class="controls">
     <button id="btn">New emoji</button>
     <label><input type="checkbox" id="pongMode" checked="false"> Pong mode</label>
-    <label><input type="checkbox" id="curlMode"> Curl mode</label>
+    <label><input type="checkbox" id="curlMode" checked> Curl mode</label>
     <label><input type="checkbox" id="gradMode"> Gradient mode</label>
     <label><input type="checkbox" id="remoteTilt"> Remote tilt</label>
     <span id="remoteTiltStatus" class="small"></span>


### PR DESCRIPTION
Make curl mode the default on startup, ensuring both the UI checkbox and internal state are active.

---
<a href="https://cursor.com/background-agent?bcId=bc-21497292-729b-4cc6-8dd3-ef1eaf77dd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21497292-729b-4cc6-8dd3-ef1eaf77dd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

